### PR TITLE
fix typo: make python 3.5+ compiles

### DIFF
--- a/lazy/_thunk.c
+++ b/lazy/_thunk.c
@@ -719,7 +719,7 @@ THUNK_INPLACE(isub, PyNumber_InPlaceSubtract)
 THUNK_INPLACE(imul, PyNumber_InPlaceMultiply)
 
 #if LZ_HAS_MATMUL
-THUNK_INPLACE(thunk_imatmul, PyNumber_InPlaceMatrixMultiply)
+THUNK_INPLACE(imatmul, PyNumber_InPlaceMatrixMultiply)
 #endif
 
 THUNK_INPLACE(ifloordiv, PyNumber_InPlaceFloorDivide)


### PR DESCRIPTION
Hi, I just found this typo caused failed builds with Python 3.5+